### PR TITLE
Update props.components as functions to component({results, render})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+### v5.0.0 (2018/3/22)
+
+**Breaking Changes**
+
+* When a function is included in the `components` array, it will now be called
+  with a different signature. Previously, it was called with one argument, `results`,
+  an array of the currently-accumulated results.
+
+  In React Composer v5, the function will be called with an object with two properties,
+  `results` and `render`. `results` is the same value as before, and `render` is the
+  render prop that you should place on the [React element](https://reactjs.org/docs/glossary.html#elements)
+  that is returned by the function.
+
+* `mapResult` and `renderPropName` have been removed. The new signature of the function
+  described above gives you the information that you need to map the results, or to use
+  a custom render prop name.
+
+If you need help migrating from an earlier version of React Composer, we encourage you to
+read the new examples in the README. They demonstrate how you can use the new
+API to accomplish the things that you previously used `renderPropName` and `mapResult` for.
+
 ### v4.1.0 (2018/2/10)
 
 **Improvements**

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import Composer from 'react-composer';
 Install using [npm](https://www.npmjs.com):
 
 ```
-npm install -S react-composer
+npm install react-composer
 ```
 
 or [yarn](https://yarnpkg.com/):
@@ -261,10 +261,7 @@ Alternatively, you can leverage the flexibility of the `props.components` as fun
 Here are some examples of render prop components that benefit from React Composer:
 
 * React's new Context API. See [this example](https://codesandbox.io/s/92pj14134y) by [Kent Dodds](https://twitter.com/kentcdodds).
-  <<<<<<< HEAD
-* # [React Request](https://github.com/jamesplease/react-request)
-* [React Request](https://github.com/jmeas/react-request)
-  > > > > > > > Update README for new components as functions API
+* [React Request](https://github.com/jamesplease/react-request)
 
 Do you know of a component that you think benefits from React Composer? Open a Pull Request and add it to the list!
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The render prop components to compose. This is an array of [React elements](http
 <Composer
   components={[
     // React elements may be passed for basic use cases
-    // props.render will be provided via React.cloneElement
+    // props.children will be provided via React.cloneElement
     <Outer />,
 
     // Render functions may be passed for added flexibility and control

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-composer",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Compose render prop components",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 
 export default function Composer(props) {
-  return renderRecursive(props.components, [], props.children);
+  return renderRecursive(props.children, props.components);
 }
 
 Composer.propTypes = {
@@ -14,12 +14,13 @@ Composer.propTypes = {
 
 /**
  * Recursively build up elements from props.components and accumulate `results` along the way.
- * @param {Array.<ReactElement|Function>} remaining
- * @param {Array} results
  * @param {function} render
+ * @param {Array.<ReactElement|Function>} remaining
+ * @param {Array} [results]
  * @returns {ReactElement}
  */
-function renderRecursive(remaining, results, render) {
+function renderRecursive(render, remaining, results) {
+  results = results || [];
   // Once components is exhausted, we can render out the results array.
   if (!remaining[0]) {
     return render(results);
@@ -28,7 +29,7 @@ function renderRecursive(remaining, results, render) {
   // Continue recursion for remaining items.
   // results.concat([value]) ensures [...results, value] instead of [...results, ...value]
   function nextRender(value) {
-    return renderRecursive(remaining.slice(1), results.concat([value]), render);
+    return renderRecursive(render, remaining.slice(1), results.concat([value]));
   }
 
   // Each props.components entry is either an element or function [element factory]

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ export default function Composer(props) {
   return renderRecursive(props.components, [], props.children);
 }
 
-// Figure out WTF transform-react-remove-prop-types isn't really working
 Composer.propTypes = {
   children: PropTypes.func.isRequired,
   components: PropTypes.arrayOf(

--- a/src/index.js
+++ b/src/index.js
@@ -1,63 +1,41 @@
-import React from 'react';
+import { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 
-export default function Composer({
-  components,
-  children,
-  renderPropName,
-  mapResult
-}) {
-  if (typeof children !== 'function') {
-    return null;
-  }
-
-  /**
-   * Recursively build up elements from props.components and accumulate `results` along the way.
-   * @param {Array.<ReactElement|Function>} components
-   * @param {Array} results
-   * @returns {ReactElement}
-   */
-  function chainComponents(components, results) {
-    // Once components is exhausted, we can render out the results array.
-    if (!components[0]) {
-      return children(results);
-    }
-
-    return React.cloneElement(
-      // Each props.components entry is either an element or function [element factory]
-      // When it is a function, produce an element by invoking it with currently accumulated results.
-      typeof components[0] === 'function'
-        ? components[0](results)
-        : components[0],
-      // Enhance the element's props with the render prop.
-      {
-        [renderPropName]() {
-          return chainComponents(
-            // Remove the current component and continue.
-            components.slice(1),
-            // results.concat([mapped]) ensures [...results, mapped] instead of [...results, ...mapped]
-            results.concat(
-              mapResult ? [mapResult.apply(null, arguments)] : arguments[0]
-            )
-          );
-        }
-      }
-    );
-  }
-
-  return chainComponents(components, []);
+export default function Composer(props) {
+  return renderRecursive(props.components, [], props.children);
 }
 
+// Figure out WTF transform-react-remove-prop-types isn't really working
 Composer.propTypes = {
-  children: PropTypes.func,
+  children: PropTypes.func.isRequired,
   components: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.element, PropTypes.func])
-  ),
-  renderPropName: PropTypes.string,
-  mapResult: PropTypes.func
+  ).isRequired
 };
 
-Composer.defaultProps = {
-  components: [],
-  renderPropName: 'children'
-};
+/**
+ * Recursively build up elements from props.components and accumulate `results` along the way.
+ * @param {Array.<ReactElement|Function>} remaining
+ * @param {Array} results
+ * @param {function} render
+ * @returns {ReactElement}
+ */
+function renderRecursive(remaining, results, render) {
+  // Once components is exhausted, we can render out the results array.
+  if (!remaining[0]) {
+    return render(results);
+  }
+
+  // Continue recursion for remaining items.
+  // results.concat([value]) ensures [...results, value] instead of [...results, ...value]
+  function nextRender(value) {
+    return renderRecursive(remaining.slice(1), results.concat([value]), render);
+  }
+
+  // Each props.components entry is either an element or function [element factory]
+  return typeof remaining[0] === 'function'
+    ? // When it is a function, produce an element by invoking it with "render component values".
+      remaining[0]({ results, render: nextRender })
+    : // When it is an element, enhance the element's props with the render prop.
+      cloneElement(remaining[0], { children: nextRender });
+}


### PR DESCRIPTION
These changes give all power/flexibility to the `props.components` as function entries which essentially become render prop functions themselves.

📝 This is a breaking change

This reduces API surface area and covers advanced use cases such as composing components with differing render prop names as discussed in #37 and multi-argument producers.

Example covering all major use cases (also see tests for further coverage/examples):

```jsx
<Composer
  components={[
    // React elements may be passed for simple/basic use cases.
    // Assumes single value produced such as `props.children(producedValue)`
    <Echo value="outer" />,

    // OR A function may be passed to produce an element.

    // Utilizing outer results for inner components
    ({ render, results: [outerResult] }) => (
      <Echo value={`${outerResult.value} + middle`} children={render} />
    ),
    
    // Differing render prop signature (multi-arg producers)
    ({ /* results, */ render }) => (
      <DoubleEcho value="spaghetti">
        {(one, two) => render([one, two])}
      </DoubleEcho>
    ),
    
    // Differing render prop names...
    ({ /* results, */ render }) => (
      <EchoRenderProp value="spaghetti" renderProp={render} />
    )
    ]}
  ]}
  children={/* ... */}
/>
```

#### TODO 

- [x] Update tests to reflect new behavior
- [x] Change the signature from `components[n](results)` to `components[n]({results, render})`
- [x] Eliminate `props.renderPropName` and `props.mapResult`. All use cases now covered by `props.components` as render functions
- [x] Refactor Composer, extract `renderRecursive` outside of render
  - 📝 Not entirely necessary, but with `index.js` being such a small module already, this refactor sort of just happened during the process...
- [x] Require `props.children` and `props.components` (📝 not totally necessary, but considering this is already a breaking change tempting to squeeze in)
- [x] Update docs (see https://github.com/jamesplease/react-composer/blob/a77449db49ed238d5c97526a1e803c8094514c1d/README.md)

---

This originally came up in #38 see discussion here https://github.com/jmeas/react-composer/pull/38#issuecomment-364801597