### PR TITLE
5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
+### v5.0.1 (2018/7/29)
+
+- Smaller file size
+
 ### v5.0.0 (2018/3/22)
 
 **Breaking Changes**
 
-* When a function is included in the `components` array, it will now be called
+- When a function is included in the `components` array, it will now be called
   with a different signature. Previously, it was called with one argument, `results`,
   an array of the currently-accumulated results.
 
@@ -13,7 +17,7 @@
   render prop that you should place on the [React element](https://reactjs.org/docs/glossary.html#elements)
   that is returned by the function.
 
-* `mapResult` and `renderPropName` have been removed. The new signature of the function
+- `mapResult` and `renderPropName` have been removed. The new signature of the function
   described above gives you the information that you need to map the results, or to use
   a custom render prop name.
 
@@ -25,13 +29,13 @@ API to accomplish the things that you previously used `renderPropName` and `mapR
 
 **Improvements**
 
-* ~20% smaller file size.
+- ~20% smaller file size.
 
 ### v4.0.0 (2018/2/8)
 
 **Breaking**
 
-* The components now render in the opposite order. What this means is that the
+- The components now render in the opposite order. What this means is that the
   first item in the `components` array will not be the _outermost_ element.
   Previously, it was the _innermost_ element.
 
@@ -43,14 +47,14 @@ API to accomplish the things that you previously used `renderPropName` and `mapR
 
 **Bug Fixes**
 
-* This ensures that the argument passed to functions within the `components`
+- This ensures that the argument passed to functions within the `components`
   array is always a new array.
 
 ### v3.1.0 (2018/2/8)
 
 **New Features**
 
-* Within the `components` array, you may now specify a `function` that returns
+- Within the `components` array, you may now specify a `function` that returns
   a [React Element](https://reactjs.org/docs/glossary.html#elements).
   The function will be called with the currently accumulated results.
 
@@ -58,7 +62,7 @@ API to accomplish the things that you previously used `renderPropName` and `mapR
 
 **Bug Fixes**
 
-* Ensures the array passed to the render prop is a new object each time
+- Ensures the array passed to the render prop is a new object each time
 
 ### v3.0.0 (2018/2/3)
 
@@ -67,14 +71,14 @@ named `render`. Accordingly, this library has been updated to use `children` as 
 
 **Breaking**
 
-* `<Composer/>` now uses `children` as the render prop, rather than `render`.
-* The default `renderPropName` is now `"children"` rather than `"render"`
+- `<Composer/>` now uses `children` as the render prop, rather than `render`.
+- The default `renderPropName` is now `"children"` rather than `"render"`
 
 ### v2.1.0 (2018/1/22)
 
 **New Features**
 
-* A new prop has been added: `mapResult`. This allows you to use React Composer with
+- A new prop has been added: `mapResult`. This allows you to use React Composer with
   render prop components that call their own render prop with more than one argument.
 
 ### v2.0.0 (2018/1/22)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-composer",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Compose render prop components",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Removing prop-types ( #54 ) shrinks the size of this lib. This also tests out the new build step from @JaKXz ( #56 ) :v: