### PR TITLE
Add TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "Compose render prop components",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf dist es tmp lib",
     "test": "jest",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",
-    "build": "npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:commonjs",
+    "build": "npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:commonjs && cp src/index.d.ts lib/",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env NODE_ENV=development BABEL_ENV=build rollup -c -i src/index.js -o dist/react-composer.js",
@@ -40,6 +41,7 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@types/react": "^16.7.13",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-jest": "^22.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,77 @@
 /// <reference types="react" />
+
+/**
+ * Examples of type usage
+ * 
+ * The simplest case, where the render function is provided as children,
+ * and is a unary function
+
+    interface StringRenderAsChildrenProps {
+        children?: (a: string) => React.ReactElement<any>;
+    }
+    const StringRenderAsChildren: React.SFC<
+        StringRenderAsChildrenProps
+    > = {} as any;
+
+ * When the render function is provided as a render prop, use the form
+ * ({ render }) => <Component render={render}
+
+    interface StringRenderAsRenderProps {
+        render?: (a: string) => React.ReactElement<any>;
+    }
+    const StringRenderAsRender: React.SFC<StringRenderAsRenderProps> = {} as any;
+
+ * When the render function is non-unary
+
+    interface StringNumberRenderAsChildrenProps {
+        children?: (a: string, b: number) => React.ReactElement<any>;
+    }
+    const StringNumberRenderAsChildren: React.SFC<
+        StringNumberRenderAsChildrenProps
+    > = {} as any;
+
+
+ * When the render function is non-unary, and also provided as a render prop,
+ * instead of children
+
+    interface StringNumberRenderAsRenderProps {
+        render?: (a: string, b: number) => React.ReactElement<any>;
+    }
+    const StringNumberRenderAsRender: React.SFC<
+        StringNumberRenderAsRenderProps
+    > = {} as any;
+
+/**
+ * Type arguments provided to Composer are the types of the arguments
+ * to the render functions for each respective component. If the function is
+ * non-unary, e.g. (a: string, b: number) => Element, then use the Array tuple
+ * form, i.e. [string, number]
+ *
+ * The components props is required to be the same length as the number of
+ * type arguments, and will cause a compile error if not.
+ *
+ * When the ({ render }) => <Component render={render} /> form is used inside
+ * the components array, then the type of render is correct for each element
+ * in the array
+ 
+    const Example = () => (
+        <Composer<string, [string, number], string, [string, number]>
+            components={[
+                <StringRenderAsChildren />,
+                <StringNumberRenderAsChildren />,
+                ({ render }) => <StringRenderAsRender render={render} />,
+                ({ render }) => <StringNumberRenderAsRender render={render} />
+            ]}
+        >
+            {([string1, [string2, number2], string3, [string4, number4]]) => {
+                // The injected arguments string1, string2 etc. should all
+                // be typed correctly
+                return null;
+            }}
+        </Composer>
+    );
+ */
+
 /**
  * Functions of varying arity that are used to type the "render" in
  * an element in the components prop, when used as:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,174 @@
+/// <reference types="react" />
+/**
+ * Functions of varying arity that are used to type the "render" in
+ * an element in the components prop, when used as:
+ * ({ render }) => <Element />
+ */
+type A1Render<T> = (props: T) => React.ReactElement<any>;
+type A2Render<A, B> = (a: A, b: B) => React.ReactElement<any>;
+type A3Render<A, B, C> = (a: A, b: B, c: C) => React.ReactElement<any>;
+type A4Render<A, B, C, D> = (a: A, b: B, c: C, d: D) => React.ReactElement<any>;
+type A5Render<A, B, C, D, E> = (
+  a: A,
+  b: B,
+  c: C,
+  d: D,
+  e: E
+) => React.ReactElement<any>;
+
+/**
+ * Convert array-tuples into functions of appropriate arity
+ */
+type RenderFn<T> = T extends [infer A, infer B, infer C, infer D, infer E]
+  ? A5Render<A, B, C, D, E>
+  : T extends [infer A, infer B, infer C, infer D]
+  ? A4Render<A, B, C, D>
+  : T extends [infer A, infer B, infer C]
+  ? A3Render<A, B, C>
+  : T extends [infer A, infer B]
+  ? A2Render<A, B>
+  : A1Render<T>;
+
+/**
+ * An element in the array passed to the components prop
+ * Can either be a rendered element, or a function of the form
+ * ({ render }) => <Element />
+ */
+type Component<T> =
+  | React.ReactElement<T>
+  | ((props: { render: RenderFn<T> }) => React.ReactElement<any>);
+
+/**
+ * In the absence of well-typed variadics, conditional types are used to
+ * create an array-like type of the correct length
+ */
+type Components<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> = T10 extends void
+  ? T9 extends void
+    ? T8 extends void
+      ? T7 extends void
+        ? T6 extends void
+          ? T5 extends void
+            ? T4 extends void
+              ? T3 extends void
+                ? T2 extends void
+                  ? T1 extends void
+                    ? []
+                    : [Component<T1>]
+                  : [Component<T1>, Component<T2>]
+                : [Component<T1>, Component<T2>, Component<T3>]
+              : [Component<T1>, Component<T2>, Component<T3>, Component<T4>]
+            : [
+                Component<T1>,
+                Component<T2>,
+                Component<T3>,
+                Component<T4>,
+                Component<T5>
+              ]
+          : [
+              Component<T1>,
+              Component<T2>,
+              Component<T3>,
+              Component<T4>,
+              Component<T5>,
+              Component<T6>
+            ]
+        : [
+            Component<T1>,
+            Component<T2>,
+            Component<T3>,
+            Component<T4>,
+            Component<T5>,
+            Component<T6>,
+            Component<T7>
+          ]
+      : [
+          Component<T1>,
+          Component<T2>,
+          Component<T3>,
+          Component<T4>,
+          Component<T5>,
+          Component<T6>,
+          Component<T7>,
+          Component<T8>
+        ]
+    : [
+        Component<T1>,
+        Component<T2>,
+        Component<T3>,
+        Component<T4>,
+        Component<T5>,
+        Component<T6>,
+        Component<T7>,
+        Component<T8>,
+        Component<T9>
+      ]
+  : [
+      Component<T1>,
+      Component<T2>,
+      Component<T3>,
+      Component<T4>,
+      Component<T5>,
+      Component<T6>,
+      Component<T7>,
+      Component<T8>,
+      Component<T9>,
+      Component<T10>
+    ];
+
+/**
+ * In the absence of well-typed variadics in TypeScript, generics
+ * are used to create an array of the correct length based on the
+ * provided type parameters.
+ */
+type InjectedArgs<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> = T10 extends void
+  ? T9 extends void
+    ? T8 extends void
+      ? T7 extends void
+        ? T6 extends void
+          ? T5 extends void
+            ? T4 extends void
+              ? T3 extends void
+                ? T2 extends void
+                  ? T1 extends void
+                    ? []
+                    : [T1]
+                  : [T1, T2]
+                : [T1, T2, T3]
+              : [T1, T2, T3, T4]
+            : [T1, T2, T3, T4, T5]
+          : [T1, T2, T3, T4, T5, T6]
+        : [T1, T2, T3, T4, T5, T6, T7]
+      : [T1, T2, T3, T4, T5, T6, T7, T8]
+    : [T1, T2, T3, T4, T5, T6, T7, T8, T9]
+  : [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10];
+
+/**
+ * components - the array of render-props components to aggregate
+ * children - the aggregated render function
+ */
+interface ReactComposerProps<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
+  components: Components<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>;
+  children: (
+    injected: InjectedArgs<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+  ) => React.ReactElement<any> | null;
+}
+
+/**
+ * The Composer component
+ */
+declare class Composer<
+  T1 = void,
+  T2 = void,
+  T3 = void,
+  T4 = void,
+  T5 = void,
+  T6 = void,
+  T7 = void,
+  T8 = void,
+  T9 = void,
+  T10 = void
+> extends React.Component<
+  ReactComposerProps<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+> {}
+
+export default Composer;


### PR DESCRIPTION
As discussed in #40 and #59, this PR adds a definitions file (index.d.ts) that provides typings for the library.  Due to current TS limitations with respect to variadic types, the syntax is a bit messy.  These types will support up to 10 components being passed in in the `components` prop. Up to 5 arguments are supported when the render function is non-unary.  If you are aware that common usage of react-composer would exceed these numbers, then I can certainly make the types support more, but my experience of render-props components is that these are probably high-end for how people are likely to use them.

The index.d.ts file is located in the src file, alongside the index.js for which it defines types. I have added a `cp` command at the end of the npm build script to move this to an appropriate directory that is included in the npm distribution.

It adds a dev dependency on @types/react - this is only really present to make it easier to work with the definitions in the future should they need improvement/change. It should have no impact on the distributed bundles.

There is example usage of these types in comments at the top of the index.d.ts file. These can copied to test the types work as expected, but also serve as a reference for TypeScript users - when using new typings it is common to view their definitions, and examples are most likely to be seen in this file.

Please let me know if you have any comments or improvements, or if the types don't work correctly in any way.